### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/1149184c-5785-47f1-80ca-fb1cbc0946f6/3c750c08-f565-4352-a6e1-f50d5df3e329/_apis/work/boardbadge/5e9385c2-aef6-4d4d-8d1a-047d4d06d30f)](https://dev.azure.com/aiw-devops/1149184c-5785-47f1-80ca-fb1cbc0946f6/_boards/board/t/3c750c08-f565-4352-a6e1-f50d5df3e329/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1719](https://dev.azure.com/aiw-devops/1149184c-5785-47f1-80ca-fb1cbc0946f6/_workitems/edit/1719). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.